### PR TITLE
Add Error Tracking (Sentry)

### DIFF
--- a/src/HoloCure.Launcher.Base/LauncherBase.BuildInfo.cs
+++ b/src/HoloCure.Launcher.Base/LauncherBase.BuildInfo.cs
@@ -7,7 +7,7 @@ namespace HoloCure.Launcher.Base;
 
 partial class LauncherBase
 {
-    protected abstract IBuildInfo BuildInfo { get; }
+    public abstract IBuildInfo BuildInfo { get; }
 }
 
 public interface IBuildInfo

--- a/src/HoloCure.Launcher.Desktop/HoloCure.Launcher.Desktop.csproj
+++ b/src/HoloCure.Launcher.Desktop/HoloCure.Launcher.Desktop.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup Label="Package References">
     <PackageReference Include="DiscordRichPresence" Version="1.0.175" />
+    <PackageReference Include="Sentry" Version="3.24.0" />
   </ItemGroup>
 
   <ItemGroup Label="Resources">

--- a/src/HoloCure.Launcher.Desktop/LauncherGameDesktop.cs
+++ b/src/HoloCure.Launcher.Desktop/LauncherGameDesktop.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 using System.IO;
 using HoloCure.Launcher.Desktop.Components;
+using HoloCure.Launcher.Desktop.Utils;
 using HoloCure.Launcher.Game;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
@@ -20,6 +21,13 @@ public class LauncherGameDesktop : LauncherGame
     private const int window_height = 800;
 
     private DependencyContainer dependencies = null!;
+
+    private SentryLogger sentryLogger;
+
+    public LauncherGameDesktop()
+    {
+        sentryLogger = new SentryLogger(this);
+    }
 
     protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent) => dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
@@ -51,5 +59,11 @@ public class LauncherGameDesktop : LauncherGame
 
         LoadComponentAsync(new DRPComponent());
         LoadComponentAsync(new UpdaterComponent());
+    }
+
+    protected override void Dispose(bool isDisposing)
+    {
+        base.Dispose(isDisposing);
+        sentryLogger.Dispose();
     }
 }

--- a/src/HoloCure.Launcher.Desktop/Utils/SentryLogger.cs
+++ b/src/HoloCure.Launcher.Desktop/Utils/SentryLogger.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) Tomat. Licensed under the GPL v3 License.
+// See the LICENSE-GPL file in the repository root for full license text.
+
+using System;
+using System.IO;
+using HoloCure.Launcher.Base;
+using osu.Framework;
+using osu.Framework.Logging;
+using Sentry;
+using Sentry.Protocol;
+
+namespace HoloCure.Launcher.Desktop.Utils;
+
+public class SentryLogger : IDisposable
+{
+    private LauncherBase game;
+    private readonly IDisposable? sentrySession;
+
+    public SentryLogger(LauncherBase game)
+    {
+        this.game = game;
+        sentrySession = SentrySdk.Init(options =>
+        {
+            if (game.BuildInfo.IsDeployedBuild) options.Dsn = "https://265de30d478a413db48e350e3d36a515@sentry.tomat.dev/3";
+            options.AutoSessionTracking = true;
+            options.IsEnvironmentUser = false; // ensure user isn't tracked; try to scrub away more information if any exists?
+            options.Release = $"{LauncherBase.GAME_NAME}@{game.BuildInfo.AssemblyVersion.ToString()}-{game.BuildInfo.ReleaseChannel}";
+        });
+
+        Logger.NewEntry += processLogEntry;
+    }
+
+    private void processLogEntry(LogEntry entry)
+    {
+        if (entry.Level < LogLevel.Verbose) return;
+
+        if (entry.Exception is { } ex)
+        {
+            if (!shouldSubmitException(ex)) return;
+
+            // framework does some weird exception redirection which means sentry does not see unhandled exceptions using its automatic methods.
+            // but all unhandled exceptions still arrive via this pathway. we just need to mark them as unhandled for tagging purposes.
+            // easiest solution is to check the message matches what the framework logs this as.
+            // see https://github.com/ppy/osu-framework/blob/f932f8df053f0011d755c95ad9a2ed61b94d136b/osu.Framework/Platform/GameHost.cs#L336
+            bool wasUnhandled = entry.Message == @"An unhandled error has occurred.";
+            bool wasUnobserved = entry.Message == @"An unobserved error has occurred.";
+
+            // see https://github.com/getsentry/sentry-dotnet/blob/c6a660b1affc894441c63df2695a995701671744/src/Sentry/Integrations/TaskUnobservedTaskExceptionIntegration.cs#L39
+            if (wasUnobserved) ex.Data[Mechanism.MechanismKey] = @"UnobservedTaskException";
+
+            // see https://github.com/getsentry/sentry-dotnet/blob/main/src/Sentry/Integrations/AppDomainUnhandledExceptionIntegration.cs#L38-L39
+            if (wasUnhandled) ex.Data[Mechanism.MechanismKey] = @"AppDomain.UnhandledException";
+
+            ex.Data[Mechanism.HandledKey] = !wasUnhandled;
+
+            SentrySdk.CaptureEvent(
+                new SentryEvent(ex)
+                {
+                    Message = entry.Message,
+                    Level = getSentryLevel(entry.Level)
+                },
+                scope =>
+                {
+                    // add scope contexts eventually too (running game (if any), etc.)
+                    scope.SetTag(@"os", $"{RuntimeInfo.OS} ({Environment.OSVersion})");
+                    scope.SetTag(@"processor count", Environment.ProcessorCount.ToString());
+                }
+            );
+        }
+        else
+            SentrySdk.AddBreadcrumb(entry.Message, entry.Target.ToString(), "navigation", level: getBreadcrumbLevel(entry.Level));
+    }
+
+    private BreadcrumbLevel getBreadcrumbLevel(LogLevel entryLevel) =>
+        entryLevel switch
+        {
+            LogLevel.Debug => BreadcrumbLevel.Debug,
+            LogLevel.Verbose => BreadcrumbLevel.Info,
+            LogLevel.Important => BreadcrumbLevel.Warning,
+            LogLevel.Error => BreadcrumbLevel.Error,
+            _ => throw new ArgumentOutOfRangeException(nameof(entryLevel), entryLevel, null)
+        };
+
+    private SentryLevel getSentryLevel(LogLevel entryLevel) =>
+        entryLevel switch
+        {
+            LogLevel.Debug => SentryLevel.Debug,
+            LogLevel.Verbose => SentryLevel.Info,
+            LogLevel.Important => SentryLevel.Warning,
+            LogLevel.Error => SentryLevel.Error,
+            _ => throw new ArgumentOutOfRangeException(nameof(entryLevel), entryLevel, null)
+        };
+
+    private bool shouldSubmitException(Exception exception)
+    {
+        switch (exception)
+        {
+            case IOException ioe:
+                // disk full exceptions, see https://stackoverflow.com/a/9294382
+                const int hr_error_handle_disk_full = unchecked((int)0x80070027);
+                const int hr_error_disk_full = unchecked((int)0x80070070);
+
+                if (ioe.HResult == hr_error_handle_disk_full || ioe.HResult == hr_error_disk_full) return false;
+
+                break;
+        }
+
+        return true;
+    }
+
+    #region IDisposable Impl
+
+    ~SentryLogger() => Dispose(false);
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool isDisposing)
+    {
+        Logger.NewEntry -= processLogEntry;
+        sentrySession?.Dispose();
+    }
+
+    #endregion
+}

--- a/src/HoloCure.Launcher.Game/LauncherGame.BuildInfo.cs
+++ b/src/HoloCure.Launcher.Game/LauncherGame.BuildInfo.cs
@@ -9,7 +9,7 @@ namespace HoloCure.Launcher.Game;
 
 partial class LauncherGame
 {
-    protected override IBuildInfo BuildInfo { get; } = new GameBuildInfo();
+    public override IBuildInfo BuildInfo { get; } = new GameBuildInfo();
 
     public class GameBuildInfo : IBuildInfo
     {

--- a/src/HoloCure.Launcher.Tests/LauncherGameTest.cs
+++ b/src/HoloCure.Launcher.Tests/LauncherGameTest.cs
@@ -5,7 +5,7 @@ namespace HoloCure.Launcher.Game.Tests;
 
 public class LauncherGameTest : LauncherBase
 {
-    protected override IBuildInfo BuildInfo { get; } = new TestBuildInfo();
+    public override IBuildInfo BuildInfo { get; } = new TestBuildInfo();
 
     private class TestBuildInfo : IBuildInfo
     {

--- a/src/HoloCure.Launcher.Tests/LauncherTestBrowser.cs
+++ b/src/HoloCure.Launcher.Tests/LauncherTestBrowser.cs
@@ -26,7 +26,7 @@ public class LauncherTestBrowser : LauncherBase
         host.Window.CursorState |= CursorState.Hidden;
     }
 
-    protected override IBuildInfo BuildInfo { get; } = new BrowserBuildInfo();
+    public override IBuildInfo BuildInfo { get; } = new BrowserBuildInfo();
 
     private class BrowserBuildInfo : IBuildInfo
     {

--- a/src/HoloCure.Launcher.Tests/Visual/LauncherTestScene.cs
+++ b/src/HoloCure.Launcher.Tests/Visual/LauncherTestScene.cs
@@ -10,7 +10,7 @@ public class LauncherTestScene : TestScene
 
     private class LauncherTestSceneTestRunner : LauncherBase, ITestSceneTestRunner
     {
-        protected override IBuildInfo BuildInfo { get; } = new TestSceneBuildInfo();
+        public override IBuildInfo BuildInfo { get; } = new TestSceneBuildInfo();
 
         private TestSceneTestRunner.TestRunner runner = null!;
 


### PR DESCRIPTION
This PR...

- Adds error tracking with Sentry.

We eventually need ways to:

- allow users to disable error reporting with Sentry (somewhat out of scope, needs doing once a settings page is established);
- allow users to change the Sentry endpoint (*really* out of scope but may prove useful to some users?).