### PR TITLE
Discord Rich Presence

### DIFF
--- a/src/HoloCure.Launcher.Base/Games/GameProvider.cs
+++ b/src/HoloCure.Launcher.Base/Games/GameProvider.cs
@@ -15,6 +15,9 @@ public class GameProvider
 
     public virtual Bindable<Game?> SelectedGame { get; } = new();
 
+    // THIS IS TEMPORARY; EXISTS FOR DRPC IN DESKTOP IMPL UNTIL WE REWRITE LAUNCHING
+    public virtual Bindable<Game?> PlayingGame { get; } = new();
+
     public GameProvider()
     {
         Games = new Lazy<List<Game>>(() => GetGames().ToList());

--- a/src/HoloCure.Launcher.Base/Games/HoloCure/HoloCureGame.cs
+++ b/src/HoloCure.Launcher.Base/Games/HoloCure/HoloCureGame.cs
@@ -58,6 +58,7 @@ public class HoloCureGame : Game
             RedirectStandardError = true,
             WorkingDirectory = storage.GetFullPath(hcDir)
         });
+        onAlert(GameAlert.GameStarted);
         proc?.WaitForExit();
         onAlert(GameAlert.GameExited);
     }

--- a/src/HoloCure.Launcher.Base/Rendering/Graphics/UserInterface/Screens/GameLauncherScreen.cs
+++ b/src/HoloCure.Launcher.Base/Rendering/Graphics/UserInterface/Screens/GameLauncherScreen.cs
@@ -77,14 +77,14 @@ public class GameLauncherScreen : LauncherScreen
 
                             case GameAlert.GameStarted:
                                 playButton.UpdateText("Game started!");
-                                Schedule(() => { gameProvider.PlayingGame.Value = game; /* TEMPORARY  */ });
+                                gameProvider.PlayingGame.Value = game; /* TEMPORARY  */
                                 break;
 
                             case GameAlert.GameExited:
                                 playButton.UpdateText("Play Game");
                                 playButton.Enabled.Value = true;
                                 updateButton.Enabled.Value = true;
-                                Schedule(() => { gameProvider.PlayingGame.Value = null; /* TEMPORARY  */ });
+                                gameProvider.PlayingGame.Value = null; /* TEMPORARY  */
                                 break;
 
                             case GameAlert.CheckingForUpdates:

--- a/src/HoloCure.Launcher.Base/Rendering/Graphics/UserInterface/Screens/GameLauncherScreen.cs
+++ b/src/HoloCure.Launcher.Base/Rendering/Graphics/UserInterface/Screens/GameLauncherScreen.cs
@@ -32,7 +32,7 @@ public class GameLauncherScreen : LauncherScreen
     }
 
     [BackgroundDependencyLoader]
-    private void load(TextureStore textures, Storage storage)
+    private void load(TextureStore textures, Storage storage, GameProvider gameProvider)
     {
         InternalChildren = new Drawable[]
         {
@@ -77,12 +77,14 @@ public class GameLauncherScreen : LauncherScreen
 
                             case GameAlert.GameStarted:
                                 playButton.UpdateText("Game started!");
+                                Schedule(() => { gameProvider.PlayingGame.Value = game; /* TEMPORARY  */ });
                                 break;
 
                             case GameAlert.GameExited:
                                 playButton.UpdateText("Play Game");
                                 playButton.Enabled.Value = true;
                                 updateButton.Enabled.Value = true;
+                                Schedule(() => { gameProvider.PlayingGame.Value = null; /* TEMPORARY  */ });
                                 break;
 
                             case GameAlert.CheckingForUpdates:

--- a/src/HoloCure.Launcher.Desktop/Components/DRPComponent.cs
+++ b/src/HoloCure.Launcher.Desktop/Components/DRPComponent.cs
@@ -52,7 +52,7 @@ internal class DRPComponent : Component
 
         presence.Timestamps = new Timestamps
         {
-            Start = playingGame is not null ? DateTime.Now : null
+            Start = playingGame is not null ? DateTime.UtcNow : null
         };
 
         updateStatus();

--- a/src/HoloCure.Launcher.Desktop/Components/DRPComponent.cs
+++ b/src/HoloCure.Launcher.Desktop/Components/DRPComponent.cs
@@ -1,5 +1,7 @@
-﻿using DiscordRPC;
+﻿using System;
+using DiscordRPC;
 using DiscordRPC.Message;
+using HoloCure.Launcher.Base.Games;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Logging;
@@ -13,14 +15,14 @@ internal class DRPComponent : Component
 
     private DiscordRpcClient client = null!;
 
-    private readonly RichPresence presence = new RichPresence
+    private readonly RichPresence presence = new()
     {
         Assets = new Assets { LargeImageKey = large_image_key }
     };
 
     // see: https://github.com/ppy/osu/blob/master/osu.Desktop/DiscordRichPresence.cs#L48
     [BackgroundDependencyLoader]
-    private void load()
+    private void load(GameProvider gameProvider)
     {
         client = new DiscordRpcClient(client_id)
         {
@@ -28,18 +30,31 @@ internal class DRPComponent : Component
         };
 
         client.OnReady += onReady;
-
-        // https://github.com/ppy/osu/blob/master/osu.Desktop/DiscordRichPresence.cs#L57
-        client.OnConnectionFailed += (_, _) => client.Deinitialize();
-
+        client.OnConnectionFailed += (_, _) => client.Deinitialize(); // https://github.com/ppy/osu/blob/master/osu.Desktop/DiscordRichPresence.cs#L57
         client.OnError += (_, e) => Logger.Log($"An error occurred with Discord RPC Client: {e.Code} {e.Message}", LoggingTarget.Network);
-
         client.Initialize();
+
+        gameProvider.SelectedGame.ValueChanged += e => { updatePresence(e.NewValue, gameProvider.PlayingGame.Value); };
+        gameProvider.PlayingGame.ValueChanged += e => { updatePresence(gameProvider.SelectedGame.Value, e.NewValue); };
+        updatePresence(gameProvider.SelectedGame.Value, gameProvider.PlayingGame.Value); // ensure current selected game when this component is loaded is displayed
     }
 
     private void onReady(object _, ReadyMessage __)
     {
         Logger.Log("Discord RPC Client ready.", LoggingTarget.Network, LogLevel.Debug);
+        updateStatus();
+    }
+
+    private void updatePresence(Base.Games.Game? browsingGame, Base.Games.Game? playingGame)
+    {
+        presence.Details = playingGame is null ? "Browsing games..." : "Playing game!";
+        presence.State = playingGame is null ? browsingGame is null ? "" : $"Looking at {browsingGame.GameTitle}" : $"Playing {playingGame.GameTitle}";
+
+        presence.Timestamps = new Timestamps
+        {
+            Start = playingGame is not null ? DateTime.Now : null
+        };
+
         updateStatus();
     }
 
@@ -52,7 +67,7 @@ internal class DRPComponent : Component
 
     protected override void Dispose(bool isDisposing)
     {
-        client.Dispose();
         base.Dispose(isDisposing);
+        client.Dispose();
     }
 }


### PR DESCRIPTION
This PR...

- adds extra information to the currently bare-bones Discord rich presence (states whether a game is being played, and the elapsed session playtime),
- fixes an oversight when launching HoloCure where the handler never notifies that the process has properly started.